### PR TITLE
Fix 500 server error by removing gunicorn from INSTALLED_APPS

### DIFF
--- a/skerritt_site/settings_production.py
+++ b/skerritt_site/settings_production.py
@@ -85,9 +85,6 @@ CACHES = {
     }
 }
 
-# Add Gunicorn to installed apps
-INSTALLED_APPS += ['gunicorn']
-
 # Trusted origins for CSRF
 CSRF_TRUSTED_ORIGINS = [
     'https://skerritteconomics.com',


### PR DESCRIPTION
## Summary
- Removed incorrect addition of 'gunicorn' to INSTALLED_APPS in production settings
- Gunicorn is a WSGI server, not a Django app, and should not be in INSTALLED_APPS
- This was causing a 500 server error in production when Django tried to import gunicorn as an app module

## Test plan
- [x] Verified Django configuration with production settings locally
- [x] Confirmed gunicorn still works as the WSGI server (it's installed via pip, not as a Django app)
- [x] All Django management commands work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)