### PR TITLE
Fix business valuation CTA text

### DIFF
--- a/main/templates/main/base_service_template.html
+++ b/main/templates/main/base_service_template.html
@@ -214,7 +214,7 @@ Variables needed:
     <section class="bg-light py-5">
         <div class="container text-center">
             <h2 class="h3 mb-3">Ready to Discuss Your Case?</h2>
-            <p class="lead mb-4">Get expert {{ service_name|lower }} analysis from a certified professional</p>
+            <p class="lead mb-4">Get expert {{ service_name|lower }} services from a certified professional</p>
             <div class="d-grid gap-2 d-md-block">
                 <a href="{% url 'contact' %}?service={{ service_slug }}" class="btn btn-primary btn-lg">
                     <i class="fas fa-calendar-check me-2"></i>Schedule Free Consultation


### PR DESCRIPTION
Fixed the CTA text for better grammar on all service pages. Changed from 'analysis' to 'services' so it reads properly for all service types, especially business valuation.