### PR TITLE
Fix sidebar Quick Contact Card alignment

### DIFF
--- a/main/templates/main/base_service_template.html
+++ b/main/templates/main/base_service_template.html
@@ -194,15 +194,17 @@ Variables needed:
                     
                     <!-- Quick Contact Card -->
                     <div class="card border-primary shadow-sm">
-                        <div class="card-body p-4 text-center">
-                            <h5 class="card-title">Need Expert Analysis?</h5>
-                            <p class="card-text">Get a free case evaluation today</p>
-                            <a href="tel:+12036052814" class="btn btn-primary btn-lg w-100 mb-2">
-                                <i class="fas fa-phone me-2"></i>Call Now
-                            </a>
-                            <a href="{% url 'contact' %}?service={{ service_slug }}" class="btn btn-outline-primary w-100">
-                                Request Consultation
-                            </a>
+                        <div class="card-body p-4">
+                            <h5 class="card-title text-center mb-3">Need Expert Analysis?</h5>
+                            <p class="card-text text-center mb-4">Get a free case evaluation today</p>
+                            <div class="d-grid gap-2">
+                                <a href="tel:+12036052814" class="btn btn-primary btn-lg">
+                                    <i class="fas fa-phone me-2"></i>Call Now
+                                </a>
+                                <a href="{% url 'contact' %}?service={{ service_slug }}" class="btn btn-outline-primary">
+                                    Request Consultation
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixed the alignment issue in the sidebar 'Need Expert Analysis?' card on service pages.

## Changes:
- Added explicit text-center classes to title and description
- Used Bootstrap's d-grid with gap-2 for proper button stacking
- Removed w-100 classes in favor of d-grid for better alignment
- Added proper spacing with mb-3 and mb-4 classes

This ensures the text and buttons are properly centered and aligned in the sidebar card.