### PR TITLE
Center sidebar buttons horizontally

### DIFF
--- a/main/templates/main/base_service_template.html
+++ b/main/templates/main/base_service_template.html
@@ -197,11 +197,11 @@ Variables needed:
                         <div class="card-body p-4">
                             <h5 class="card-title text-center mb-3">Need Expert Analysis?</h5>
                             <p class="card-text text-center mb-4">Get a free case evaluation today</p>
-                            <div class="d-grid gap-2">
-                                <a href="tel:+12036052814" class="btn btn-primary btn-lg">
+                            <div class="d-flex flex-column align-items-center gap-2">
+                                <a href="tel:+12036052814" class="btn btn-primary btn-lg px-5">
                                     <i class="fas fa-phone me-2"></i>Call Now
                                 </a>
-                                <a href="{% url 'contact' %}?service={{ service_slug }}" class="btn btn-outline-primary">
+                                <a href="{% url 'contact' %}?service={{ service_slug }}" class="btn btn-outline-primary px-4">
                                     Request Consultation
                                 </a>
                             </div>


### PR DESCRIPTION
Centers the buttons in the sidebar 'Need Expert Analysis?' card instead of making them full width.

## Changes:
- Changed from d-grid to d-flex with flex-column for better control
- Added align-items-center to center buttons horizontally
- Added px-5 and px-4 padding classes for appropriate button widths
- Buttons now appear centered in the middle of the card

This provides a cleaner, more professional look with properly centered buttons.

## Summary by Sourcery

Enhancements:
- Center sidebar buttons in the 'Need Expert Analysis?' card by switching from a full-width grid layout to a centered flex-column layout with added padding for balanced widths